### PR TITLE
Use `/usr/bin/env bash` as shebang

### DIFF
--- a/mapper.sh
+++ b/mapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 MAPDIR=$1
 SPAWNPOS=$2


### PR DESCRIPTION
This will enable systems that install bash in a different location to launch the shell.
Tested on FreeBSD, which installs bash to /usr/local/bin/bash.
