### PR TITLE
Fix title in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Leaftest
+# Leaftest
 
 Leaftest consists of a bash script that uses [minetestmapper](https://github.com/Rogier-5/minetest-mapper-cpp) to display the map on a leaflet based zoomable sloppy map.
 For an example, see [VanessaE survival server's map](https://daconcepts.com/vanessa/hobbies/minetest/worldmaps/Survival_World/map.html).


### PR DESCRIPTION
There was a space missing between the '#' and the title, preventing the title from being rendered properly.